### PR TITLE
fetch TEMP environment variable

### DIFF
--- a/extension/ExpandAnimations/ExpandAnimations.xba
+++ b/extension/ExpandAnimations/ExpandAnimations.xba
@@ -93,7 +93,12 @@ function renameAsExpanded(doc as Object)
   sDocUrl = doc.getURL()
   sDocFileNameWithoutExtension = GetFileNameWithoutExtension(sDocUrl, &quot;/&quot;) 
 
-  newUrlExpanded = &quot;file:///tmp/&quot; + sDocFileNameWithoutExtension + &quot;-expanded.odp&quot;
+  sTemp = Replace(Environ(&quot;TEMP&quot;), &quot;\&quot;, &quot;/&quot;)
+  If sTemp = &quot;&quot; Then
+    sTemp=&quot;/tmp&quot;
+  EndIf
+
+  newUrlExpanded = &quot;file:///&quot; + sTemp + &quot;/&quot; + sDocFileNameWithoutExtension + &quot;-expanded.odp&quot;
   doc.storeToUrl(newUrlExpanded, Array())
   
   &#39; reloading the saved document

--- a/src/ExpandAnimations.bas
+++ b/src/ExpandAnimations.bas
@@ -90,7 +90,12 @@ function renameAsExpanded(doc as Object)
   sDocUrl = doc.getURL()
   sDocFileNameWithoutExtension = GetFileNameWithoutExtension(sDocUrl, "/") 
 
-  newUrlExpanded = "file:///tmp/" + sDocFileNameWithoutExtension + "-expanded.odp"
+  sTemp = Replace(Environ("TEMP"), "\", "/")
+  If sTemp = "" Then
+    sTemp="/tmp"
+  EndIf
+
+  newUrlExpanded = "file:///" + sTemp + "/" + sDocFileNameWithoutExtension + "-expanded.odp"
   doc.storeToUrl(newUrlExpanded, Array())
   
   ' reloading the saved document


### PR DESCRIPTION
As pointed out [here](https://github.com/monperrus/ExpandAnimations/commit/57d2c7062e73d82965042561d09ccf2c259b1229#commitcomment-34187581), the hardcoded /tmp folder only works on unix-like systems.
This PR evaluates the environment variable TEMP, which should be set on Windows to a reasonable value by default.
Hopefully fixes #29. @katz-hm, could you, please, give it a try?