### PR TITLE
Set font color and name of slide number

### DIFF
--- a/src/ExpandAnimations.bas
+++ b/src/ExpandAnimations.bas
@@ -183,6 +183,8 @@ function fixateSlideNumber(doc as Object, slide as Object, slideNr as Integer, s
             copy.Text.Style = shape.Text.Style
             copy.Text.CharHeight = shape.Text.CharHeight
             copy.Text.CharFontFamily = shape.Text.CharFontFamily
+            copy.Text.CharFontName = shape.Text.CharFontName
+            copy.Text.CharColor = shape.Text.CharColor
             copy.Position = shape.Position
             copy.Size = shape.Size
             copy.TextVerticalAdjust = shape.TextVerticalAdjust


### PR DESCRIPTION
This PR introduces support for keeping the exakt font name and font color, as I had issues using a `sans-serif` font colored differently than black.

The exact slide number font formatting was:
- Font: Liberation Sans
- Color: white

However the expanded slide number formatting was:
- Font: Liberation Serif
- Color: black

I used LibreOffice Impress in the following version:
Version: 7.0.6.2
Build ID: 00(Build:2)
CPU threads: 8; OS: Linux 5.12; UI render: default; VCL: gtk3
Locale: de-DE (de_DE.utf8); UI: de-DE
7.0.6-3
Calc: threaded